### PR TITLE
Fix deprecation of 'pygments' configuration option

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 markdown: redcarpet
-pygments: true
+highlighter: pygments
 
 title_tag_text: Solo, a Jekyll Theme
 h1_tag_text: Solo


### PR DESCRIPTION
replaced 'pygments: true' with 'highlighter: pygments'

Signed-off-by: Jai Govindani govindani@gmail.com
